### PR TITLE
Inherit restart directive from common services

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -428,9 +428,9 @@ services:
   # pgweb :22222
   #-----------------------------------------------------
   pgweb:
+    <<: *services-common
     image: sosedoff/pgweb
     container_name: pgweb 
-    restart: always
     ports: 
       - 22222:8081
     environment:
@@ -443,9 +443,9 @@ services:
   # pgweb:6543
   #-----------------------------------------------------
   pgweb2:
+    <<: *services-common
     image: sosedoff/pgweb
     container_name: pgweb2
-    restart: always
     ports: 
       - 22223:8081
     environment:


### PR DESCRIPTION
We prefer smaller PRs that merge more often.

## Haiku-length summary
I run and I run
Looking ever and anon
Alas no db

### Additional details 
When running the docker dev stack i noticed that the two pgweb containers were always running on restart and just trying forever to connect to DBs that were not runnning.  This removes the `restart: always` directive from those two services, instead inheriting them from services-common.

To test, you can rerun `make docker` and then restart your docker engine and ensure that these two services are not running.

## PR Checklist: Submitter

- [X]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [X]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [X]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [X]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the E2E tests pass.
- [X]   Do manual testing locally. 
- [ ]   If that’s not applicable for some reason, check this box.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area still works.

## PR Checklist: Reviewer

- [ ]   Pull the branch to your local environment and run `make macup ; make e2e"` (FIXME)
- [ ]   Manually test out the changes locally
- [ ]   Check this box if not applicable in this case.
- [ ]   Check that the PR has appropriate tests.

The larger the PR, the stricter we should be about these points.
